### PR TITLE
Bump debug to 2.6.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "tj@vision-media.ca"
   },
   "dependencies": {
-    "debug": "~2.2.0",
+    "debug": "~2.6.7",
     "escape-regexp": "0.0.1",
     "amp-message": "~0.1.1",
     "amp": "~0.3.1"


### PR DESCRIPTION
In order to get rid off of buggy[1] dependencies we need to get a more recent debug package

Ref.:
[1] https://snyk.io/test/npm/debug/2.2.0