### PR TITLE
bugfix send `msg` to all established peers.

### DIFF
--- a/lib/sockets/pub.js
+++ b/lib/sockets/pub.js
@@ -38,13 +38,10 @@ PubSocket.prototype.__proto__ = Socket.prototype;
 PubSocket.prototype.send = function(msg){
   var socks = this.socks;
   var len = socks.length;
-  var sock;
-
   var buf = this.pack(arguments);
 
-  for (var i = 0; i < len; i++) {
-    sock = socks[i];
-    if (sock.writable) sock.write(buf);
+  for (var sock of socks) {
+      if (sock.writable) sock.write(buf);
   }
 
   return this;


### PR DESCRIPTION
fix Cannot read property 'writable' of undefined