### PR TITLE
[Fixes #12] bugfix Fixing paths with spaces when using Unix Sockets

### DIFF
--- a/lib/sockets/sock.js
+++ b/lib/sockets/sock.js
@@ -251,7 +251,7 @@ Socket.prototype.connect = function(port, host, fn){
       fn = host;
       host = null;
       fn = undefined;
-      port = port.pathname;
+      port = decodeURIComponent(port.pathname);
     } else {
       host = port.hostname || '0.0.0.0';
       port = parseInt(port.port, 10);
@@ -354,7 +354,7 @@ Socket.prototype.bind = function(port, host, fn){
     if (port.pathname) {
       fn = host;
       host = null;
-      port = port.pathname;
+      port = decodeURIComponent(port.pathname);
       unixSocket = true;
     } else {
       host = port.hostname || '0.0.0.0';


### PR DESCRIPTION
Added `decodeURIComponent` to the `port.pathname` when using a Unix Socket to allow file paths with spaces in them.